### PR TITLE
Modifications for Coconut SVSM

### DIFF
--- a/examples/aarch64/src/main.rs
+++ b/examples/aarch64/src/main.rs
@@ -102,7 +102,7 @@ extern "C" fn main(x0: u64, x1: u64, x2: u64, x3: u64) {
                 debug!("Found VirtIO MMIO device at {:?}", region);
 
                 let header = NonNull::new(region.starting_address as *mut VirtIOHeader).unwrap();
-                match unsafe { MmioTransport::new(header) } {
+                match unsafe { MmioTransport::<HalImpl>::new(header) } {
                     Err(e) => warn!("Error creating VirtIO MMIO transport: {}", e),
                     Ok(transport) => {
                         info!(

--- a/examples/riscv/src/main.rs
+++ b/examples/riscv/src/main.rs
@@ -69,7 +69,7 @@ fn virtio_probe(node: FdtNode) {
             node.compatible().map(Compatible::first),
         );
         let header = NonNull::new(vaddr as *mut VirtIOHeader).unwrap();
-        match unsafe { MmioTransport::new(header) } {
+        match unsafe { MmioTransport::<HalImpl>::new(header) } {
             Err(e) => warn!("Error creating VirtIO MMIO transport: {}", e),
             Ok(transport) => {
                 info!(

--- a/src/device/blk.rs
+++ b/src/device/blk.rs
@@ -59,7 +59,7 @@ impl<H: Hal, T: Transport> VirtIOBlk<H, T> {
         info!("config: {:?}", config);
         // Safe because config is a valid pointer to the device configuration space.
         let capacity = unsafe {
-            volread!(config, capacity_low) as u64 | (volread!(config, capacity_high) as u64) << 32
+            volread!(H, config, capacity_low) as u64 | (volread!(H, config, capacity_high) as u64) << 32
         };
         info!("found a block device of size {}KB", capacity / 2);
 

--- a/src/device/console.rs
+++ b/src/device/console.rs
@@ -135,8 +135,8 @@ impl<H: Hal, T: Transport> VirtIOConsole<H, T> {
             // SAFETY: self.config_space is a valid pointer to the device configuration space.
             unsafe {
                 Some(Size {
-                    columns: volread!(self.config_space, cols),
-                    rows: volread!(self.config_space, rows),
+                    columns: volread!(H, self.config_space, cols),
+                    rows: volread!(H, self.config_space, rows),
                 })
             }
         } else {

--- a/src/device/gpu.rs
+++ b/src/device/gpu.rs
@@ -45,8 +45,8 @@ impl<H: Hal, T: Transport> VirtIOGpu<H, T> {
         // read configuration space
         let config_space = transport.config_space::<Config>()?;
         unsafe {
-            let events_read = volread!(config_space, events_read);
-            let num_scanouts = volread!(config_space, num_scanouts);
+            let events_read = volread!(H, config_space, events_read);
+            let num_scanouts = volread!(H, config_space, num_scanouts);
             info!(
                 "events_read: {:#x}, num_scanouts: {:#x}",
                 events_read, num_scanouts

--- a/src/device/input.rs
+++ b/src/device/input.rs
@@ -111,9 +111,9 @@ impl<H: Hal, T: Transport> VirtIOInput<H, T> {
         let size;
         // Safe because config points to a valid MMIO region for the config space.
         unsafe {
-            volwrite!(self.config, select, select as u8);
-            volwrite!(self.config, subsel, subsel);
-            size = volread!(self.config, size);
+            volwrite!(H, self.config, select, select as u8);
+            volwrite!(H, self.config, subsel, subsel);
+            size = volread!(H, self.config, size);
             let size_to_copy = min(usize::from(size), out.len());
             for (i, out_item) in out.iter_mut().take(size_to_copy).enumerate() {
                 *out_item = addr_of!((*self.config.as_ptr()).data[i]).vread();

--- a/src/device/net/dev_raw.rs
+++ b/src/device/net/dev_raw.rs
@@ -33,11 +33,11 @@ impl<H: Hal, T: Transport, const QUEUE_SIZE: usize> VirtIONetRaw<H, T, QUEUE_SIZ
         let mac;
         // Safe because config points to a valid MMIO region for the config space.
         unsafe {
-            mac = volread!(config, mac);
+            mac = volread!(H, config, mac);
             debug!(
                 "Got MAC={:02x?}, status={:?}",
                 mac,
-                volread!(config, status)
+                volread!(H, config, status)
             );
         }
         let send_queue = VirtQueue::new(

--- a/src/device/net/mod.rs
+++ b/src/device/net/mod.rs
@@ -81,18 +81,30 @@ bitflags! {
     }
 }
 
+/// Status
+#[derive(Copy, Clone, Debug, Default, Eq, PartialEq, FromBytes, IntoBytes, Immutable)]
+pub struct Status(u16);
+
 bitflags! {
-    #[derive(Copy, Clone, Debug, Default, Eq, PartialEq)]
-    struct Status: u16 {
+    /// a
+    impl Status: u16 {
+        /// a
         const LINK_UP = 1;
+        /// a
         const ANNOUNCE = 2;
     }
 }
 
+/// InterruptStatus
+#[derive(Copy, Clone, Debug, Default, Eq, PartialEq, FromBytes, IntoBytes, Immutable)]
+pub struct InterruptStatus(u32);
+
 bitflags! {
-    #[derive(Copy, Clone, Debug, Default, Eq, PartialEq)]
-    struct InterruptStatus : u32 {
+    /// a
+    impl InterruptStatus : u32 {
+        /// a
         const USED_RING_UPDATE = 1 << 0;
+        /// a
         const CONFIGURATION_CHANGE = 1 << 1;
     }
 }

--- a/src/device/socket/vsock.rs
+++ b/src/device/socket/vsock.rs
@@ -252,7 +252,7 @@ impl<H: Hal, T: Transport, const RX_BUFFER_SIZE: usize> VirtIOSocket<H, T, RX_BU
         debug!("config: {:?}", config);
         // Safe because config is a valid pointer to the device configuration space.
         let guest_cid = unsafe {
-            volread!(config, guest_cid_low) as u64 | (volread!(config, guest_cid_high) as u64) << 32
+            volread!(H, config, guest_cid_low) as u64 | (volread!(H, config, guest_cid_high) as u64) << 32
         };
         debug!("guest cid: {guest_cid:?}");
 

--- a/src/hal.rs
+++ b/src/hal.rs
@@ -1,6 +1,8 @@
 #[cfg(test)]
 pub mod fake;
 
+use zerocopy::{FromBytes, Immutable, IntoBytes};
+
 use crate::{Error, Result, PAGE_SIZE};
 use core::{marker::PhantomData, ptr::NonNull};
 
@@ -150,7 +152,7 @@ pub unsafe trait Hal {
     /// `src` must be properly alinged and reside at a readable memory address.
     unsafe fn mmio_read<T>(src: &T) -> T
     where
-        T: Sized + Copy,
+        T: FromBytes + Immutable
     {
         unsafe { (src as *const T).read_volatile() }
     }
@@ -163,9 +165,9 @@ pub unsafe trait Hal {
     /// # Safety
     ///
     /// `dst` must be properly alinged and reside at a writable memory address.
-    unsafe fn mmio_write<T: Sized>(dst: &mut T, value: T)
+    unsafe fn mmio_write<T>(dst: &mut T, value: T)
     where
-        T: Sized + Copy,
+        T: IntoBytes + Immutable
     {
         unsafe {
             (dst as *mut T).write_volatile(value);

--- a/src/hal.rs
+++ b/src/hal.rs
@@ -138,6 +138,39 @@ pub unsafe trait Hal {
     /// any other thread for the duration of this method call. The `paddr` must be the value
     /// previously returned by the corresponding `share` call.
     unsafe fn unshare(paddr: PhysAddr, buffer: NonNull<[u8]>, direction: BufferDirection);
+
+    /// Performs memory mapped read from location of `src`. `src` itself is not modified,
+    /// the value is returned instead.
+    ///
+    /// The default implementation performs a regular volatile_read. This method is intended
+    /// to be overwritten in case MMIO memory needs to be accessed in a special way (for example AMD SEV-SNP).
+    ///
+    /// # Safety
+    ///
+    /// `src` must be properly alinged and reside at a readable memory address.
+    unsafe fn mmio_read<T>(src: &T) -> T
+    where
+        T: Sized + Copy,
+    {
+        unsafe { (src as *const T).read_volatile() }
+    }
+
+    /// Performs memory mapped write of `value` to the location of `dst`.
+    ///
+    /// The default implementation performs a regular volatile_write. This method is intended
+    /// to be overwritten in case MMIO memory needs to be accessed in a special way (for example AMD SEV-SNP).
+    ///
+    /// # Safety
+    ///
+    /// `dst` must be properly alinged and reside at a writable memory address.
+    unsafe fn mmio_write<T: Sized>(dst: &mut T, value: T)
+    where
+        T: Sized + Copy,
+    {
+        unsafe {
+            (dst as *mut T).write_volatile(value);
+        }
+    }
 }
 
 /// The direction in which a buffer is passed.

--- a/src/transport/mod.rs
+++ b/src/transport/mod.rs
@@ -7,6 +7,7 @@ pub mod pci;
 
 use crate::{PhysAddr, Result, PAGE_SIZE};
 use bitflags::{bitflags, Flags};
+use zerocopy::{FromBytes, Immutable, IntoBytes};
 use core::{fmt::Debug, ops::BitAnd, ptr::NonNull};
 use log::debug;
 
@@ -102,10 +103,13 @@ pub trait Transport {
     fn config_space<T: 'static>(&self) -> Result<NonNull<T>>;
 }
 
+/// DeviceStatus
+#[derive(Copy, Clone, Debug, Default, Eq, PartialEq, IntoBytes, FromBytes, Immutable)]
+pub struct DeviceStatus(u32);
+
 bitflags! {
     /// The device status field. Writing 0 into this field resets the device.
-    #[derive(Copy, Clone, Debug, Default, Eq, PartialEq)]
-    pub struct DeviceStatus: u32 {
+    impl DeviceStatus : u32 {
         /// Indicates that the guest OS has found the device and recognized it
         /// as a valid virtio device.
         const ACKNOWLEDGE = 1;


### PR DESCRIPTION
- Introduce custom MMIO acces functions via the Hal trait
- Use zerocopy FromBytes, IntoBytes for all MMIO accesses

ToDo: Finish and check the work on the PCI transport.